### PR TITLE
Address changes 2021

### DIFF
--- a/uctMaths/competition/admin.py
+++ b/uctMaths/competition/admin.py
@@ -47,7 +47,6 @@ class SchoolAdmin(ImportExportModelAdmin):
 			url("^school_summary/", self.school_summary),
 			url("^update_school_entry_status/", self.update_school_entry_status),
 			url("^school_certificate_list/", self.school_certificate_list),
-			url("^clear_email_addresses/", self.clear_email_addresses),
 			url("^generate_grade_answer_sheets/", self.generate_grade_answer_sheets)
 		]
 		return my_urls + urls
@@ -66,10 +65,6 @@ class SchoolAdmin(ImportExportModelAdmin):
 	def school_certificate_list(self, request):
 	    return compadmin.certificate_list(request)
 	
-	def clear_email_addresses(self, request):
-		compadmin.remove_emails_addresses()
-		return HttpResponseRedirect("../")
-
 	def generate_grade_answer_sheets(self, request):
 		return compadmin.generate_grade_answer_sheets(request)
 

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -735,8 +735,6 @@ def export_courier_address(request, school_list):
                 errors.append("city")
                 if(not full[2]):
                     errors.append("postal code") 
-        if(not ischool.phone):
-            errors.append("phone number")
         errorMessage ='No %s assigned to school' % ((', ').join(errors))
         if(errors):
             if(ischool.entered == 0):

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -376,14 +376,6 @@ def remove_user_assoc(school_list):
         school.assigned_to = None
         school.save()
 
-def remove_emails_addresses():
-    """ Remove all addresses and school phone numbers from the database """
-    school_list = School.objects.all()
-    for school in school_list:
-        school.address = ""
-        school.phone = ""
-        school.save()
-
 #Called by admin to generate formatted 'tag list' for selected schools
 def output_schooltaglists(school_list):
     """ Generate the tags for a School QuerySet. Served as a single text file in HttpResponse. """

--- a/uctMaths/competition/interface/admin/school_changelist.html
+++ b/uctMaths/competition/interface/admin/school_changelist.html
@@ -26,10 +26,6 @@
             {% csrf_token %}
                 <button type="submit" class="actionButton">Download school certificate list</button>
         </form>
-        <form action="clear_email_addresses/" method="POST">
-            {% csrf_token %}
-                <button type="submit" class="actionButton">Clear phone numbers and addresses for selected school(s)</button>
-        </form>
         <form action="generate_grade_answer_sheets/" method="POST">
             {% csrf_token %}
                 <button type="submit" class="actionButton">Generate answer sheets for entered students separated by grade</button>

--- a/uctMaths/competition/interface/printer_entry.html
+++ b/uctMaths/competition/interface/printer_entry.html
@@ -60,8 +60,8 @@
 
             <div>
                 <h2>Delivery Address</h2>
-                <p>{{delivery_address}}</p>
-                {% if (contact_phone %}<p><b>Phone:</b> {{ contact_phone }}</p>
+                <p>{{ delivery_address|linebreaks }}</p>
+		{% if contact_phone%}<p><b>Phone:</b> {{ contact_phone }}</p>{% endif%}
                 <h2>Responsible Teacher</h2>
                 {% csrf_token %}
                 <table width="500">

--- a/uctMaths/competition/interface/printer_entry.html
+++ b/uctMaths/competition/interface/printer_entry.html
@@ -59,6 +59,9 @@
             </div>
 
             <div>
+                <h2>Delivery Address</h2>
+                <p>{{delivery_address}}</p>
+                {% if (contact_phone %}<p><b>Phone:</b> {{ contact_phone }}</p>
                 <h2>Responsible Teacher</h2>
                 {% csrf_token %}
                 <table width="500">

--- a/uctMaths/competition/views.py
+++ b/uctMaths/competition/views.py
@@ -71,6 +71,8 @@ def printer_entry_result(request, school_list=None):
             c = {'type':'Students',
                 'timestamp':timestamp,
                 'schooln':assigned_school,
+                'delivery_address':assigned_school.address,
+                'contact_phone':assigned_school.phone,
                 'responsible_teacher':responsible_teacher[0],
                 'student_list':individual_list,
                 'pair_list':pair_list,


### PR DESCRIPTION
This implements the following changes, needed given the changes to the programme this year:

* Remove the option to clear the school addresses and phone numbers – this is no longer required and is dangerous to leave enabled. It is also misleading as it says "for selected school(s)" but apparently operates on all of them
* Add the delivery address to the school confirmation sheet (this will be used to prepare the package for the courier)
* When exporting the school confirmation sheets, don’t add the school to the Errors tab of the Excel file if there is a missing phone number (this is not a critical field). Add it to the School Addresses tab.

I haven't actually run these changes, but just prepared them speculatively

