### PR TITLE
Alternate teacher

### DIFF
--- a/uctMaths/competition/admin.py
+++ b/uctMaths/competition/admin.py
@@ -177,7 +177,7 @@ class SchoolAdmin(ImportExportModelAdmin):
 
 class ResponsibleTeacherAdmin(ImportExportModelAdmin):
 	change_form_template = "admin/rt_changeform.html"
-	list_display = ('school', 'firstname', 'surname', 'phone_primary', 'phone_alt', 'email', 'report_downloaded', 'answer_sheet_downloaded')
+	list_display = ('school', 'firstname', 'surname', 'phone_primary', 'phone_alt', 'phone_cell', 'email_school', 'email_personal', 'report_downloaded', 'answer_sheet_downloaded')
 
 #Displays different fields for SchoolStudent and archives SchoolStudent
 class SchoolStudentAdmin(ImportExportModelAdmin):

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -685,6 +685,9 @@ def assign_student_awards():
                         student.save()
                     else:
                         break
+    
+    student_list = SchoolStudent.objects.all()
+
 
 def school_summary(request):
     """ Return for DL a summary list of all the schools that have made an entry; also create a "email these people" line with all the relevant email addresses. Or something like that."""
@@ -721,13 +724,14 @@ def export_courier_address(request, school_list):
     error_row = 0
     for ischool in school_list:
         errors = []
-        resp_teacher = ResponsibleTeacher.objects.filter(school = ischool)
+        resp_teacher = ResponsibleTeacher.objects.filter(school = ischool).filter(is_primary=True)
+        alt_resp_teacher = ResponsibleTeacher.objects.filter(school = ischool).filter(is_primary=False)
         full = ischool.address.split(',')
         full+=['']*(3-len(full))
         
         
 
-        if(not resp_teacher):
+        if not (resp_teacher or alt_resp_teacher):
             errors.append("responsible teacher")
         if(not full[0]):
             errors.append("address")
@@ -807,7 +811,7 @@ def school_summary_sheet(school_list, wb_sheet, rank_extend=False):
     wb_sheet.write(1,0,'Generated')
     wb_sheet.write(1,1,'%s'%(timestamp_now()))
 
-    header = ['School', 'Location', 'Resp. Teach Name', 'Resp. Teach. Email', 'Resp. Teach. Phone', 'Resp. Teach. Alt Phone', 'Individuals', 'Pairs', 'Total']
+    header = ['School', 'Location', 'Resp. Teach. Name', 'Resp. Teach. Email (School)', 'Resp. Teach. Email (Personal)', 'Resp. Teach. Phone', 'Resp. Teach. Alt Phone', 'Resp. Teach. Cell', 'Alt. Teach. Name', 'Alt Teach. Email (School)', 'Alt. Teach. Email (Personal)', 'Alt. Teach. Phone', 'Alt. Teach. Alt Phone', 'Alt. Teach. Cell', 'Individuals', 'Pairs', 'Total']
     if rank_extend:
         header.append('Rank')
         header.append('Score')
@@ -822,11 +826,12 @@ def school_summary_sheet(school_list, wb_sheet, rank_extend=False):
     for school_obj in school_list:
         try: #Try get the student list for the school assigned to the requesting user
             student_list = SchoolStudent.objects.all().filter(school=school_obj)
-            resp_teacher = ResponsibleTeacher.objects.get(school=school_obj)
+            resp_teacher = ResponsibleTeacher.objects.filter(is_primary=True).get(school=school_obj)
+            alt_resp_teacher = ResponsibleTeacher.objects.filter(is_primary=False).get(school=school_obj)
         except exceptions.ObjectDoesNotExist:#Non-entry
             pass #Handled in if-not-empty statement below
 
-        if student_list and resp_teacher: #If the lists are not empty
+        if student_list and (resp_teacher or alt_resp_teacher): #If the lists are not empty
 
             grade_summary = gradeBucket(student_list) #Bin into categories (Pairing, grade)
             count_individuals = 0
@@ -841,16 +846,25 @@ def school_summary_sheet(school_list, wb_sheet, rank_extend=False):
             wb_sheet.write(cell_row_offset,1,unicode(school_obj.location))
             wb_sheet.write(cell_row_offset,2,('%s %s')%(resp_teacher.firstname, resp_teacher.surname))
             wb_sheet.write(cell_row_offset,3,resp_teacher.email_school)
-            wb_sheet.write(cell_row_offset,4,resp_teacher.phone_primary)
-            wb_sheet.write(cell_row_offset,5,resp_teacher.phone_alt)
-            wb_sheet.write(cell_row_offset,6,count_individuals)
-            wb_sheet.write(cell_row_offset,7,count_pairs)
-            wb_sheet.write(cell_row_offset,8,int(count_pairs*2 + count_individuals))
+            wb_sheet.write(cell_row_offset,4,resp_teacher.email_personal)
+            wb_sheet.write(cell_row_offset,5,resp_teacher.phone_primary)
+            wb_sheet.write(cell_row_offset,6,resp_teacher.phone_alt)
+            wb_sheet.write(cell_row_offset,7,resp_teacher.phone_cell)
+            wb_sheet.write(cell_row_offset,8,('%s %s')%(alt_resp_teacher.firstname, alt_resp_teacher.surname))
+            wb_sheet.write(cell_row_offset,9,alt_resp_teacher.email_school)
+            wb_sheet.write(cell_row_offset,10,alt_resp_teacher.email_personal)
+            wb_sheet.write(cell_row_offset,11,alt_resp_teacher.phone_primary)
+            wb_sheet.write(cell_row_offset,12,alt_resp_teacher.phone_alt)
+            wb_sheet.write(cell_row_offset,13,alt_resp_teacher.phone_cell)
+            wb_sheet.write(cell_row_offset,14,count_individuals)
+            wb_sheet.write(cell_row_offset,15,count_pairs)
+            wb_sheet.write(cell_row_offset,16,int(count_pairs*2 + count_individuals))
             if rank_extend:
-                wb_sheet.write(cell_row_offset,9,school_obj.rank)
-                wb_sheet.write(cell_row_offset,10,school_obj.score)
+                wb_sheet.write(cell_row_offset,17,school_obj.rank)
+                wb_sheet.write(cell_row_offset,18,school_obj.score)
 
             responsible_teacher_mailinglist.append(resp_teacher.email_school)
+            responsible_teacher_mailinglist.append(alt_resp_teacher.email_school)
     
     wb_sheet.write(3,0,'Mailing list')
     wb_sheet.write(3,1,', '.join(responsible_teacher_mailinglist))
@@ -966,11 +980,11 @@ def output_PRN_files():
 def update_school_entry_status():
     school_objects = School.objects.all()
     for school_obj in school_objects:
-        try:
-            responsible_teachers = ResponsibleTeacher.objects.get(school=school_obj)
+        responsible_teachers = ResponsibleTeacher.objects.filter(school=school_obj)
+        if responsible_teachers > 0:
             school_obj.entered=1 #If a responsible teacher is found; the school has entered
             school_obj.save()
-        except exceptions.ObjectDoesNotExist:
+        else:
             school_obj.entered=0
             school_obj.answer_sheets_emailed = None
             school_obj.save()

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -751,7 +751,7 @@ def export_courier_address(request, school_list):
         resp_teacher = resp_teacher[0]
         cell_row_offset = cell_row_offset + 1
         wb_sheet.write(cell_row_offset,0,unicode(ischool.name))
-        wb_sheet.write(cell_row_offset,1,resp_teacher.email)
+        wb_sheet.write(cell_row_offset,1,resp_teacher.email_school)
         wb_sheet.write(cell_row_offset,2,full[0])
         wb_sheet.write(cell_row_offset,3,full[2])
         wb_sheet.write(cell_row_offset,4,full[1])
@@ -840,7 +840,7 @@ def school_summary_sheet(school_list, wb_sheet, rank_extend=False):
             wb_sheet.write(cell_row_offset,0,unicode(school_obj.name))
             wb_sheet.write(cell_row_offset,1,unicode(school_obj.location))
             wb_sheet.write(cell_row_offset,2,('%s %s')%(resp_teacher.firstname, resp_teacher.surname))
-            wb_sheet.write(cell_row_offset,3,resp_teacher.email)
+            wb_sheet.write(cell_row_offset,3,resp_teacher.email_school)
             wb_sheet.write(cell_row_offset,4,resp_teacher.phone_primary)
             wb_sheet.write(cell_row_offset,5,resp_teacher.phone_alt)
             wb_sheet.write(cell_row_offset,6,count_individuals)
@@ -850,7 +850,7 @@ def school_summary_sheet(school_list, wb_sheet, rank_extend=False):
                 wb_sheet.write(cell_row_offset,9,school_obj.rank)
                 wb_sheet.write(cell_row_offset,10,school_obj.score)
 
-            responsible_teacher_mailinglist.append(resp_teacher.email)
+            responsible_teacher_mailinglist.append(resp_teacher.email_school)
     
     wb_sheet.write(3,0,'Mailing list')
     wb_sheet.write(3,1,', '.join(responsible_teacher_mailinglist))

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -685,9 +685,6 @@ def assign_student_awards():
                         student.save()
                     else:
                         break
-    
-    student_list = SchoolStudent.objects.all()
-
 
 def school_summary(request):
     """ Return for DL a summary list of all the schools that have made an entry; also create a "email these people" line with all the relevant email addresses. Or something like that."""

--- a/uctMaths/competition/forms.py
+++ b/uctMaths/competition/forms.py
@@ -102,13 +102,15 @@ class ResponsibleTeacherForm (ModelForm):
         fields = "__all__"
 
 class ResponsibleTeacherForm(forms.Form):
-        fields = ['school', 'firstname','surname', 'phone_primary','phone_alt', 'email']
+        fields = ['school', 'firstname','surname', 'phone_primary','phone_alt', 'phone_cell', 'email_school', 'email_personal']
         school = forms.ModelChoiceField(required=False, widget = forms.Select(), queryset = School.objects.all()) #gives all school options
         firstname = forms.CharField()
         surname = forms.CharField()
         phone_primary = forms.CharField()
         phone_alt = forms.CharField()
-        email = forms.CharField()
+        phone_cell = forms.CharField()
+        email_school = forms.CharField()
+        email_personal = forms.CharField()
 
 #*****************************************
 

--- a/uctMaths/competition/interface/entry_review.html
+++ b/uctMaths/competition/interface/entry_review.html
@@ -26,14 +26,18 @@
                 <th>Surname</th>
                 <th>Phone </th>
                 <th>Phone (Alternative)</th>
-                <th>Email </th>
+                <th>Cellphone</th>
+                <th>School Email </th>
+                <th>Personal Email</th>
             </tr>
             <tr>
                 <td>{{responsible_teacher.firstname}}</td>
                 <td>{{responsible_teacher.surname}}</td>
                 <td>{{responsible_teacher.phone_primary}}</td>
                 <td>{{responsible_teacher.phone_alt}}</td>
-                <td>{{responsible_teacher.email}}</td>
+                <td>{{responsible_teacher.cellphone}}</td>
+                <td>{{responsible_teacher.email_school}}</td>
+                <td>{{responsible_teacher.email_personal}}</td>
             </tr>
         </table>
     </div>
@@ -42,7 +46,7 @@
 
     <div>
         <h1>Alternate Responsible Teacher</h1>
-        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. This field is not compulsory.</p>
+        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. <i> All fields marked with an <b>asterisk (*) must be filled for an entry to be valid.</b></i></p>
         <p> {{ ierror }}</p>
         {% csrf_token %}
 
@@ -52,14 +56,18 @@
                 <th>Surname</th>
                 <th>Phone </th>
                 <th>Phone (Alternative)</th>
-                <th>Email </th>
+                <th>Cellphone</th>
+                <th>School Email </th>
+                <th>Personal Email</th>
             </tr>
             <tr>
                 <td>{{alt_responsible_teacher.firstname}}</td>
                 <td>{{alt_responsible_teacher.surname}}</td>
                 <td>{{alt_responsible_teacher.phone_primary}}</td>
                 <td>{{alt_responsible_teacher.phone_alt}}</td>
-                <td>{{alt_responsible_teacher.email}}</td>
+                <td>{{alt_responsible_teacher.cellphone}}</td>
+                <td>{{alt_responsible_teacher.email_school}}</td>
+                <td>{{alt_responsible_teacher.email_personal}}</td>
             </tr>
         </table>
     </div>

--- a/uctMaths/competition/interface/entry_review.html
+++ b/uctMaths/competition/interface/entry_review.html
@@ -42,9 +42,9 @@
 
     <div>
         <h1>Alternate Responsible Teacher</h1>
-        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. This field is not compulsory</p>
+        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. This field is not compulsory.</p>
         <p> {{ ierror }}</p>
-        % csrf_token %
+        {% csrf_token %}
 
         <table>
             <tr>

--- a/uctMaths/competition/interface/entry_review.html
+++ b/uctMaths/competition/interface/entry_review.html
@@ -38,6 +38,32 @@
         </table>
     </div>
 
+    <!-- register alternate responsible teacher from here --->
+
+    <div>
+        <h1>Alternate Responsible Teacher</h1>
+        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. This field is not compulsory</p>
+        <p> {{ ierror }}</p>
+        % csrf_token %
+
+        <table>
+            <tr>
+                <th>First Name</th>
+                <th>Surname</th>
+                <th>Phone </th>
+                <th>Phone (Alternative)</th>
+                <th>Email </th>
+            </tr>
+            <tr>
+                <td>{{alt_responsible_teacher.firstname}}</td>
+                <td>{{alt_responsible_teacher.surname}}</td>
+                <td>{{alt_responsible_teacher.phone_primary}}</td>
+                <td>{{alt_responsible_teacher.phone_alt}}</td>
+                <td>{{alt_responsible_teacher.email}}</td>
+            </tr>
+        </table>
+    </div>
+
 
 
     <!-- register invigilators from here -->

--- a/uctMaths/competition/interface/newstudents.html
+++ b/uctMaths/competition/interface/newstudents.html
@@ -58,6 +58,33 @@
         </table>
     </div>
 
+    <!-- register alternate responsible teacher from here --->
+
+    <div>
+        <h1>Alternate Responsible Teacher</h1>
+        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. This field is not compulsory.</p>
+        <p> {{ ierror }}</p>
+        {% csrf_token %}
+
+        <table>
+            <tr>
+                <th>First Name</th>
+                <th>Surname</th>
+                <th>Phone </th>
+                <th>Phone (Alternative)</th>
+                <th>Email </th>
+            </tr>
+            <tr>
+                <td><input type="text" class="alt_resp_firstname" name="art_firstname" value="{{alt_responsible_teacher.firstname}}"></td>
+                <td><input type="text" class="alt_resp_surname" name="art_surname" value="{{alt_responsible_teacher.surname}}"></td>
+                <td><input type ="text" class="alt_resp_phone_primary" name="art_phone_primary" value="{{alt_responsible_teacher.phone_primary}}"></td>                    
+                <td><input type ="text" class="alt_resp_phone_alt" name="art_phone_alt" value="{{alt_responsible_teacher.phone_alt}}"></td>
+                <td><input id="rmail" class="alt_resp_mail" type ="text" name="art_email" value={{alt_responsible_teacher.email|lower}}></td>
+                <input type ="hidden" name="alt_rt_registered_by" value ={{ user.id }} >
+            </tr>
+        </table>
+    </div>
+
 
 
     <!-- register invigilators from here -->

--- a/uctMaths/competition/interface/newstudents.html
+++ b/uctMaths/competition/interface/newstudents.html
@@ -45,14 +45,18 @@
                 <th>Surname*</th>
                 <th>Phone*</th>
                 <th>Phone (Alternative)</th>
-                <th>Email* </th>
+                <th>Cellphone</th>
+                <th>School Email* </th>
+                <th>Personal Email</th>
             </tr>
             <tr>	<!-- the required attribute does not work with IE9 and lower -->
                 <td><input type="text" class="resp_firstname" name="rt_firstname" required value="{{responsible_teacher.firstname}}"></td>
-                <td><input type="text" class="resp_surname" name="rt_surname" value="{{responsible_teacher.surname}}"></td>
+                <td><input type="text" class="resp_surname" name="rt_surname" required value="{{responsible_teacher.surname}}"></td>
                 <td><input type ="text" class="resp_phone_primary" name="rt_phone_primary" required value="{{responsible_teacher.phone_primary}}"></td>                    
                 <td><input type ="text" class="resp_phone_alt" name="rt_phone_alt" value="{{responsible_teacher.phone_alt}}"></td>
-                <td><input id="rmail" class="resp_mail" type ="text" name="rt_email" required value={{responsible_teacher.email|lower}}></td>
+                <td><input type ="text" class="resp_cell" name="rt_phone_cell" value="{{responsible_teacher.phone_cell}}"></td>
+                <td><input id="rmail" class="resp_mail_school" type ="text" name="rt_email_school" required value={{responsible_teacher.email_school|lower}}></td>
+                <td><input id="rmail" class="resp_mail_personal" type ="text" name="rt_email_personal" value={{responsible_teacher.email_personal|lower}}></td>
                 <input type ="hidden" name="rt_registered_by" value ={{ user.id }} >
             </tr>
         </table>
@@ -62,24 +66,28 @@
 
     <div>
         <h1>Alternate Responsible Teacher</h1>
-        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. This field is not compulsory.</p>
+        <p>An Alternate Responsible Teacher can be assigned to take over correspondence if the primary responsible teacher leaves the school. <i> All fields marked with an <b>asterisk (*) must be filled for an entry to be valid.</b></i></p>
         <p> {{ ierror }}</p>
         {% csrf_token %}
 
         <table>
             <tr>
-                <th>First Name</th>
-                <th>Surname</th>
-                <th>Phone </th>
+                <th>First Name*</th>
+                <th>Surname*</th>
+                <th>Phone* </th>
                 <th>Phone (Alternative)</th>
-                <th>Email </th>
+                <th>Cellphone</th>
+                <th>School Email* </th>
+                <th>Personal Email</th>
             </tr>
             <tr>
-                <td><input type="text" class="alt_resp_firstname" name="art_firstname" value="{{alt_responsible_teacher.firstname}}"></td>
-                <td><input type="text" class="alt_resp_surname" name="art_surname" value="{{alt_responsible_teacher.surname}}"></td>
-                <td><input type ="text" class="alt_resp_phone_primary" name="art_phone_primary" value="{{alt_responsible_teacher.phone_primary}}"></td>                    
+                <td><input type="text" class="alt_resp_firstname" name="art_firstname" required value="{{alt_responsible_teacher.firstname}}"></td>
+                <td><input type="text" class="alt_resp_surname" name="art_surname" required value="{{alt_responsible_teacher.surname}}"></td>
+                <td><input type ="text" class="alt_resp_phone_primary" name="art_phone_primary" required value="{{alt_responsible_teacher.phone_primary}}"></td>                    
                 <td><input type ="text" class="alt_resp_phone_alt" name="art_phone_alt" value="{{alt_responsible_teacher.phone_alt}}"></td>
-                <td><input id="rmail" class="alt_resp_mail" type ="text" name="art_email" value={{alt_responsible_teacher.email|lower}}></td>
+                <td><input type ="text" class="alt_resp_cell" name="art_phone_cell" value="{{alt_responsible_teacher.phone_cell}}"></td>
+                <td><input id="rmail" class="alt_resp_mail_school" type ="text" name="art_email_school" required value={{alt_responsible_teacher.email_school|lower}}></td>
+                <td><input id="rmail" class="alt_resp_mail_personal" type ="text" name="art_email_personal" value={{alt_responsible_teacher.email_personal|lower}}></td>
                 <input type ="hidden" name="alt_rt_registered_by" value ={{ user.id }} >
             </tr>
         </table>

--- a/uctMaths/competition/models.py
+++ b/uctMaths/competition/models.py
@@ -159,14 +159,16 @@ class Invigilator(models.Model):
 
 class ResponsibleTeacher(models.Model):
     # ResponsibleTeacher registered by SchoolUser
-    # One ResponsibleTeacher to one school
+    # One Primary ResponsibleTeacher and one Alternate ResponsibleTeacher to one school
 
     school      = models.ForeignKey('School', db_column='School') 
     firstname   = models.CharField(max_length=255L, db_column='First_name', verbose_name="First name")
     surname     = models.CharField(max_length=255L, db_column='Surname')
     phone_primary = models.CharField(max_length=15L, db_column='Phone (Primary)', blank=True)
     phone_alt   = models.CharField(max_length=15L, db_column='Phone (Alternative)', blank=True)
-    email       = models.CharField(max_length=50L, db_column='Email', blank=False)
+    phone_cell  = models.CharField(max_length=15L, db_column='Cellphone', blank=True)
+    email_school   = models.CharField(max_length=50L, db_column='Email (School)', blank=False)
+    email_personal = models.CharField(max_length=50L, db_column='Email (Personal)', blank=True) 
     is_primary  = models.BooleanField(db_column='Is_primary', default="true")
     report_downloaded = models.DateTimeField(db_column='Report_downloaded', null=True, verbose_name="Results report downloaded manually by teacher")
     answer_sheet_downloaded = models.DateTimeField(db_column='Answer_sheet_downloaded', blank=True, null=True, verbose_name="Answer sheets downloaded manually by teacher")

--- a/uctMaths/competition/models.py
+++ b/uctMaths/competition/models.py
@@ -168,8 +168,8 @@ class ResponsibleTeacher(models.Model):
     phone_alt   = models.CharField(max_length=15L, db_column='Phone (Alternative)', blank=True)
     email       = models.CharField(max_length=50L, db_column='Email', blank=False)
     is_primary  = models.BooleanField(db_column='Is_primary', default="true")
-    report_downloaded = models.DateTimeField(db_column='Report_downloaded', blank=True, verbose_name="Results report downloaded manually by teacher")
-    answer_sheet_downloaded = models.DateTimeField(db_column='Answer_sheet_downloaded', blank=True, verbose_name="Answer sheets downloaded manually by teacher")
+    report_downloaded = models.DateTimeField(db_column='Report_downloaded', null=True, verbose_name="Results report downloaded manually by teacher")
+    answer_sheet_downloaded = models.DateTimeField(db_column='Answer_sheet_downloaded', blank=True, null=True, verbose_name="Answer sheets downloaded manually by teacher")
     def __str__(self):
         return self.surname+', '+self.firstname+', '+self.phone_primary
     def __unicode__(self):

--- a/uctMaths/competition/models.py
+++ b/uctMaths/competition/models.py
@@ -2,7 +2,7 @@
 # defines django models (correspond to db tables)
 from __future__ import unicode_literals
 from django.db import models
-from django.core.validators import MaxValueValidator, MinValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator, ip_address_validator_map
 from django.contrib.auth.models import User
 #Import_export models(https://django-import-export.readthedocs.org/en/latest/getting_started.html)
 from import_export import resources, fields
@@ -165,8 +165,9 @@ class ResponsibleTeacher(models.Model):
     firstname   = models.CharField(max_length=255L, db_column='First_name', verbose_name="First name")
     surname     = models.CharField(max_length=255L, db_column='Surname')
     phone_primary = models.CharField(max_length=15L, db_column='Phone (Primary)', blank=True)
-    phone_alt = models.CharField(max_length=15L, db_column='Phone (Alternative)', blank=True)
+    phone_alt   = models.CharField(max_length=15L, db_column='Phone (Alternative)', blank=True)
     email       = models.CharField(max_length=50L, db_column='Email', blank=False)
+    is_primary  = models.BooleanField(db_column='Is_primary', default="true")
     report_downloaded = models.DateTimeField(db_column='Report_downloaded', blank=True, verbose_name="Results report downloaded manually by teacher")
     answer_sheet_downloaded = models.DateTimeField(db_column='Answer_sheet_downloaded', blank=True, verbose_name="Answer sheets downloaded manually by teacher")
     def __str__(self):

--- a/uctMaths/competition/models.py
+++ b/uctMaths/competition/models.py
@@ -170,7 +170,7 @@ class ResponsibleTeacher(models.Model):
     email_school   = models.CharField(max_length=50L, db_column='Email (School)', blank=False)
     email_personal = models.CharField(max_length=50L, db_column='Email (Personal)', blank=True) 
     is_primary  = models.BooleanField(db_column='Is_primary', default="true")
-    report_downloaded = models.DateTimeField(db_column='Report_downloaded', null=True, verbose_name="Results report downloaded manually by teacher")
+    report_downloaded = models.DateTimeField(db_column='Report_downloaded', blank=True, null=True, verbose_name="Results report downloaded manually by teacher")
     answer_sheet_downloaded = models.DateTimeField(db_column='Answer_sheet_downloaded', blank=True, null=True, verbose_name="Answer sheets downloaded manually by teacher")
     def __str__(self):
         return self.surname+', '+self.firstname+', '+self.phone_primary

--- a/uctMaths/competition/reports.py
+++ b/uctMaths/competition/reports.py
@@ -45,7 +45,7 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     if not rteachers:
         print("No responsible teacher for school!")
         return
-    rteacher = rteachers[0]
+    rteacher = rteachers.filter(is_primary=True)[0]
     #Header
     output_string = 'Dear %s, \n\n' \
                     'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
@@ -58,9 +58,8 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     recipient_list = [rteacher.email_school]
     if cc_admin:
         recipient_list.append(compadmin.admin_emailaddress())
-
     send_email(
-        "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
+        "(Do not reply) UCT Mathematics Competition %s Answer Sheets %s" % (school.name, recipient_list),
         output_string,
         "UCT Mathematics Competition <UCTMathsCompetition@j5int.com>",
         [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
@@ -70,7 +69,6 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     arteacher = ResponsibleTeacher.objects.filter(school=school.id).filter(is_primary=False)[0]
     alt_output_string = 'Dear %s, \n\n' \
                     'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
-                    'Attached you will find a printer-friendly .pdf file that contains the answer sheets that ' \
                     'your students will write on. \n\n' \
                     'Regards,\n\n' \
                     'The UCT Mathematics Competition team'%(arteacher.firstname + " " + arteacher.surname, school.name)
@@ -79,7 +77,7 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     recipient_list = [arteacher.email_school]
     if cc_admin:
         recipient_list.append(compadmin.admin_emailaddress())
-
+    print(recipient_list)
     send_email(
         "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
         alt_output_string,

--- a/uctMaths/competition/reports.py
+++ b/uctMaths/competition/reports.py
@@ -14,7 +14,8 @@ import os
 
 def send_results(in_school, result, cc_admin=False):
     """ Formats student information for the particular user and sends it via. smtp"""
-    rteacher = ResponsibleTeacher.objects.filter(school=in_school.id)[0]
+    rteacher = ResponsibleTeacher.objects.filter(school=in_school.id).filter(is_primary=True)[0]
+    arteacher = ResponsibleTeacher.objects.filter(school=in_school.id).filter(is_primary=False)[0]
     name = rteacher.firstname + " " + rteacher.surname
     #Header
     output_string = 'Dear %s, \n\n' \
@@ -27,7 +28,7 @@ def send_results(in_school, result, cc_admin=False):
     output_string += 'Results letter for %s\nRequested by %s\n%s\n'%(in_school.name, name, UMC_datetime())
 
 
-    recipient_list = [rteacher.email]
+    recipient_list = [rteacher.email_school, arteacher.email_school]
     if cc_admin:
         recipient_list.append(compadmin.admin_emailaddress())
 
@@ -54,13 +55,34 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
                     'The UCT Mathematics Competition team'%(rteacher.firstname + " " + rteacher.surname, school.name)
     output_string += UMC_header("Answer Sheets")
     output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
-    recipient_list = [rteacher.email]
+    recipient_list = [rteacher.email_school]
     if cc_admin:
         recipient_list.append(compadmin.admin_emailaddress())
 
     send_email(
         "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
         output_string,
+        "UCT Mathematics Competition <UCTMathsCompetition@j5int.com>",
+        [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
+        recipient_list
+    )
+
+    arteacher = ResponsibleTeacher.objects.filter(school=school.id).filter(is_primary=False)[0]
+    alt_output_string = 'Dear %s, \n\n' \
+                    'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
+                    'Attached you will find a printer-friendly .pdf file that contains the answer sheets that ' \
+                    'your students will write on. \n\n' \
+                    'Regards,\n\n' \
+                    'The UCT Mathematics Competition team'%(arteacher.firstname + " " + arteacher.surname, school.name)
+    alt_output_string += UMC_header("Answer Sheets")
+    alt_output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
+    recipient_list = [arteacher.email_school]
+    if cc_admin:
+        recipient_list.append(compadmin.admin_emailaddress())
+
+    send_email(
+        "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
+        alt_output_string,
         "UCT Mathematics Competition <UCTMathsCompetition@j5int.com>",
         [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
         recipient_list

--- a/uctMaths/competition/views.py
+++ b/uctMaths/competition/views.py
@@ -63,6 +63,10 @@ def printer_entry_result(request, school_list=None):
         alt_responsible_teacher = ResponsibleTeacher.objects.filter(school = assigned_school).filter(is_primary = False)
         timestamp = str(datetime.now().strftime('%d %B %Y at %H:%M (local time)'))
         year = str(datetime.now().strftime('%Y'))
+        if responsible_teacher:
+            responsible_teacher = responsible_teacher[0]
+        else:
+            responsible_teacher = None
         if alt_responsible_teacher:
             alt_responsible_teacher = alt_responsible_teacher[0]
         else:
@@ -77,7 +81,7 @@ def printer_entry_result(request, school_list=None):
                 'schooln':assigned_school,
                 'delivery_address':assigned_school.address,
                 'contact_phone':assigned_school.phone,
-                'responsible_teacher':responsible_teacher[0],
+                'responsible_teacher':responsible_teacher,
                 'alt_responsible_teacher': alt_responsible_teacher,
                 'student_list':individual_list,
                 'pair_list':pair_list,
@@ -234,6 +238,11 @@ def entry_review(request):
         assigned_school.entered=1 #The school has made an entry
         assigned_school.save()
     
+    if responsible_teacher:
+        responsible_teacher = responsible_teacher[0]
+    else:
+        responsible_teacher = None
+
     if alt_responsible_teacher:
         alt_responsible_teacher = alt_responsible_teacher[0]
     else:
@@ -241,7 +250,7 @@ def entry_review(request):
         
     c = {'type':'Students',
         'schooln':assigned_school,
-        'responsible_teacher':responsible_teacher[0],
+        'responsible_teacher':responsible_teacher,
         'alt_responsible_teacher':alt_responsible_teacher,
         'student_list':individual_list,
         'pair_list':pair_list,
@@ -330,12 +339,14 @@ def newstudents(request):
             rtsurname = form.getlist('rt_surname','')[0]
             rtphone_primary = form.getlist('rt_phone_primary','')[0].strip().replace(' ', '')
             rtphone_alt = form.getlist('rt_phone_alt','')[0].strip().replace(' ', '')
-            rtemail = form.getlist('rt_email','')[0].strip().replace(' ', '')
+            rtphone_cell = form.getlist('rt_phone_cell','')[0].strip().replace(' ', '')
+            rtemail_school = form.getlist('rt_email_school','')[0].strip().replace(' ', '')
+            rtemail_personal = form.getlist('rt_email_personal','')[0].strip().replace(' ', '')
 
             #rtregistered_by =  User.objects.get(pk=int(form.getlist('rt_registered_by','')[0]))
             rt_query = ResponsibleTeacher(firstname = rtfirstname , surname = rtsurname, phone_primary = rtphone_primary,
-                                      phone_alt = rtphone_alt, school = rtschool,
-                                      email = rtemail, is_primary = True)
+                                      phone_alt = rtphone_alt, phone_cell=rtphone_cell, school = rtschool,
+                                      email_school = rtemail_school, email_personal=rtemail_personal, is_primary = True)
 
             #Delete responsible teacher before saving the new one
             for rt in responsible_teacher:
@@ -351,12 +362,14 @@ def newstudents(request):
             artsurname = form.getlist('art_surname','')[0]
             artphone_primary = form.getlist('art_phone_primary','')[0].strip().replace(' ', '')
             artphone_alt = form.getlist('art_phone_alt','')[0].strip().replace(' ', '')
-            artemail = form.getlist('art_email','')[0].strip().replace(' ', '')
+            artphone_cell = form.getlist('rt_phone_cell','')[0].strip().replace(' ', '')
+            artemail_school = form.getlist('rt_email_school','')[0].strip().replace(' ', '')
+            artemail_personal = form.getlist('rt_email_personal','')[0].strip().replace(' ', '')
 
             #rtregistered_by =  User.objects.get(pk=int(form.getlist('rt_registered_by','')[0]))
             art_query = ResponsibleTeacher(firstname = artfirstname , surname = artsurname, phone_primary = artphone_primary,
-                                      phone_alt = artphone_alt, school = artschool,
-                                      email = artemail, is_primary = False)
+                                      phone_alt = artphone_alt, phone_cell=artphone_cell, school = artschool,
+                                      email_school = artemail_school, email_personal=artemail_personal, is_primary = False)
 
             #Delete responsible teacher before saving the new one
             for art in alt_responsible_teacher:
@@ -454,6 +467,7 @@ def newstudents(request):
     if responsible_teacher:
         responsible_teacher = responsible_teacher[0]
     else:
+        responsible_teacher = None
         #If not null, then the form has been filled out.
         #Therefore - redirect to entry_review page
         pass #HttpResponseRedirect('../entry_review.html')
@@ -559,7 +573,7 @@ def school_select(request):
 def school_results(request):
     assigned_school = School.objects.get(assigned_to=request.user)
     if has_results(request, assigned_school):
-        report = ResponsibleTeacher.objects.get(school = assigned_school)
+        report = ResponsibleTeacher.objects.get(school = assigned_school)[0]
         report.report_downloaded = datetime.now()
         report.save()
         return compadmin.print_school_reports(request,[assigned_school])

--- a/uctMaths/competition/views.py
+++ b/uctMaths/competition/views.py
@@ -362,9 +362,9 @@ def newstudents(request):
             artsurname = form.getlist('art_surname','')[0]
             artphone_primary = form.getlist('art_phone_primary','')[0].strip().replace(' ', '')
             artphone_alt = form.getlist('art_phone_alt','')[0].strip().replace(' ', '')
-            artphone_cell = form.getlist('rt_phone_cell','')[0].strip().replace(' ', '')
-            artemail_school = form.getlist('rt_email_school','')[0].strip().replace(' ', '')
-            artemail_personal = form.getlist('rt_email_personal','')[0].strip().replace(' ', '')
+            artphone_cell = form.getlist('art_phone_cell','')[0].strip().replace(' ', '')
+            artemail_school = form.getlist('art_email_school','')[0].strip().replace(' ', '')
+            artemail_personal = form.getlist('art_email_personal','')[0].strip().replace(' ', '')
 
             #rtregistered_by =  User.objects.get(pk=int(form.getlist('rt_registered_by','')[0]))
             art_query = ResponsibleTeacher(firstname = artfirstname , surname = artsurname, phone_primary = artphone_primary,


### PR DESCRIPTION
Added an alternate responsible teacher that schools must fill in when registering students. Also split the email field into a work and personal email for the responsible teachers, as well as a cellphone field. Made the surname field compulsory and allows the report_downloaded and answer_sheet_downloaded to be null as otherwise the website broke when trying to send out confirmation emails after registration. Also added a isPrimary field to allow the database to distinguish between primary and alternate responsible teachers.

Updated the school summary sheet to include the alternate teacher fields. Updated reports generator to generate personalised emails to both the primary and alternate responsible teachers.