### PR TITLE
Fixed Alternate Teacher conflicts with confirmations

### DIFF
--- a/uctMaths/competition/confirmation.py
+++ b/uctMaths/competition/confirmation.py
@@ -20,7 +20,8 @@ def send_confirmation(request, in_school='UNDEFINED',cc_admin=False):
         name = request.user.username
     student_list = SchoolStudent.objects.filter(school = in_school)
     invigilator_list = Invigilator.objects.filter(school = in_school)
-    rteacher = ResponsibleTeacher.objects.filter(school = in_school)[0]
+    rteacher = ResponsibleTeacher.objects.filter(school = in_school).filter(is_primary = True)[0]
+    arteacher = ResponsibleTeacher.objects.filter(school = in_school).filter(is_primary = False)[0]
 
     #Header
     output_string = 'Dear %s, \n\n' \
@@ -32,7 +33,7 @@ def send_confirmation(request, in_school='UNDEFINED',cc_admin=False):
     output_string += UMC_header()
     output_string += 'Confirmation letter for %s\nRequested by %s\n%s\n'%(in_school, name, UMC_datetime())
 
-    output_string += print_responsibleTeacher(rteacher)
+    output_string += print_responsibleTeacher(rteacher, arteacher)
     if compadmin.competition_has_invigilator():
         output_string += print_invigilators(invigilator_list)
     output_string += print_students(student_list)
@@ -112,15 +113,16 @@ def print_invigilators(invigilator_list, width=60):
 
     return invig_string
 
-def print_responsibleTeacher(rteacher, width=60):
+def print_responsibleTeacher(rteacher, arteacher, width=60):
     """Print responsible teacher section"""
 
     #Heading
     rt_string = 'Responsible teacher:\n'
-    rt_string += '%-20s %-15s %-15s %-20s\n%s\n'%('Name', 'Phone','(Alternate)', 'Email','-'*80)
+    rt_string += '%-20s %-15s %-15s %-15s %-20s %-20s\n%s\n'%('Name', 'Phone','(Alternate)', 'Cellphone', 'School Email', 'Personal Email', '-'*120)
 
     try:
-        rt_string += '%-20s %-15s %-15s %-20s\n'%(rteacher.surname+', '+rteacher.firstname, rteacher.phone_primary, rteacher.phone_alt,rteacher.email) 
+        rt_string += '%-20s %-15s %-15s %-15s %-20s %-20s\n'%(rteacher.surname+', '+rteacher.firstname, rteacher.phone_primary, rteacher.phone_alt, rteacher.phone_cell, rteacher.email_school, rteacher.email_personal) 
+        rt_string += '%-20s %-15s %-15s %-15s %-20s %-20s\n'%(arteacher.surname+', '+arteacher.firstname, arteacher.phone_primary, arteacher.phone_alt, arteacher.phone_cell, arteacher.email_school, arteacher.email_personal) 
 
     except IndexError: #If the user submitted an empty form
         print 'Index Error (Confirmation email - rteacher)'

--- a/uctMaths/competition/confirmation.py
+++ b/uctMaths/competition/confirmation.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from models import SchoolStudent, School, Invigilator, Venue, ResponsibleTeacher
 from django.core.mail import EmailMessage
@@ -49,7 +50,7 @@ def send_confirmation(request, in_school='UNDEFINED',cc_admin=False):
     email = EmailMessage(
                         '(Do not reply) UCT Mathematics Competition %s Entry Confirmation'%(in_school),#Subject line
                         output_string, #Body
-                        'UCT Mathematics Competition <UCTMathsCompetition@j5int.com>',#from
+                        'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
                         recipient_list,
                         )
     result = views.printer_entry_result(request)

--- a/uctMaths/competition/interface/printer_entry.html
+++ b/uctMaths/competition/interface/printer_entry.html
@@ -70,14 +70,27 @@
                         <th align="left">Surname</th>
                         <th align="left">Phone </th>
                         <th align="left">Phone (Alternative)</th>
-                        <th align="left">Email </th>
+                        <th align="left">Cellphone</th>
+                        <th align="left">School Email </th>
+                        <th align="left">Personal Email</th>
                     </tr>
                     <tr>
                         <td>{{responsible_teacher.firstname}}</td>
                         <td>{{responsible_teacher.surname}}</td>
                         <td>{{responsible_teacher.phone_primary}}</td>
                         <td>{{responsible_teacher.phone_alt}}</td>
-                        <td>{{responsible_teacher.email}}</td>
+                        <td>{{responsible_teacher.phone_cell}}</td>
+                        <td>{{responsible_teacher.email_school}}</td>
+                        <td>{{responsible_teacher.email_personal}}</td>
+                    </tr>
+                    <tr>
+                        <td>{{alt_responsible_teacher.firstname}}</td>
+                        <td>{{alt_responsible_teacher.surname}}</td>
+                        <td>{{alt_responsible_teacher.phone_primary}}</td>
+                        <td>{{alt_responsible_teacher.phone_alt}}</td>
+                        <td>{{alt_responsible_teacher.phone_cell}}</td>
+                        <td>{{alt_responsible_teacher.email_school}}</td>
+                        <td>{{alt_responsible_teacher.email_personal}}</td>
                     </tr>
                 </table>
             </div>

--- a/uctMaths/competition/reports.py
+++ b/uctMaths/competition/reports.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from models import SchoolStudent, School, Invigilator, Venue, ResponsibleTeacher, Competition
 from django.core.mail import EmailMessage
@@ -36,7 +37,7 @@ def send_results(in_school, result, cc_admin=False):
     send_email(
                 '(Do not reply) UCT Mathematics Competition %s Competition Results'%(in_school.name),#Subject line
                 output_string, #Body
-                'UCT Mathematics Competition <UCTMathsCompetition@j5int.com>',#from
+                'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
                 [{"name": '%s' % (compadmin.get_school_report_name(in_school)), "value": result.getvalue(), "type": "application/pdf"}],
                 recipient_list
     )
@@ -60,7 +61,7 @@ def send_results(in_school, result, cc_admin=False):
     send_email(
                 '(Do not reply) UCT Mathematics Competition %s Competition Results'%(in_school.name),#Subject line
                 output_string, #Body
-                'UCT Mathematics Competition <UCTMathsCompetition@j5int.com>',#from
+                'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
                 [{"name": '%s' % (compadmin.get_school_report_name(in_school)), "value": result.getvalue(), "type": "application/pdf"}],
                 recipient_list
     )
@@ -86,7 +87,7 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     send_email(
         "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
         output_string,
-        "UCT Mathematics Competition <UCTMathsCompetition@j5int.com>",
+        'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
         [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
         recipient_list
     )
@@ -105,7 +106,7 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     send_email(
         "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
         alt_output_string,
-        "UCT Mathematics Competition <UCTMathsCompetition@j5int.com>",
+        'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
         [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
         recipient_list
     )
@@ -120,7 +121,7 @@ This email contains part of the collection of answer sheets for all students, se
     send_email(
         "(Do not reply) " + os.path.basename(pdf_attachment_filename),
         output_string,
-        "UCT Mathematics Competition <UCTMathsCompetition@j5int.com>",
+        'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
         [
             {
                 "name": os.path.basename(pdf_attachment_filename), 

--- a/uctMaths/competition/views.py
+++ b/uctMaths/competition/views.py
@@ -453,8 +453,7 @@ def newstudents(request):
                     confirmation.send_confirmation(request, assigned_school,cc_admin=True)
                     return HttpResponseRedirect('../submitted.html')
                 except Exception as e:
-                    logger = logging.getLogger(__name__)
-                    logger.exception(e)
+                    print(e)
                     return HttpResponseRedirect('../submitted_noemail.html')
             else:
                 print('This should not happen')


### PR DESCRIPTION
Fixes issues the new alternate teacher fields had with confirmations, and updated the pdf and email text to include these fields and both responsible teachers