### PR TITLE
Fix School Certificate download

### DIFF
--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -669,7 +669,8 @@ def makeCertificates(students, assigned_school):
             outFile.seek(0)
             wrapper = FileWrapper(outFile)
             response = HttpResponse(wrapper, content_type="application/x-zip-compressed")
-            response['Content-Disposition'] = 'attachment; filename=' + path
+            filename = schoolname + "_Certificates.zip"
+            response['Content-Disposition'] = 'attachment; filename=' + filename
             response['Content-Length'] = os.path.getsize(path)
             outFile.close()
         finally:

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -655,6 +655,8 @@ def makeCertificates(students, assigned_school):
         try:
             certs = []
             for student in students:
+                if student.score == 0:  # student is absent
+                    continue
                 award = student.award            
 
                 if award in certs:


### PR DESCRIPTION
- b311fff3509f85e08024fc7447fe90343474cf8c Show a nice filename when downloading a Certificate zip file

  The zip file was something like `tmp_zkljfsd_School_name.zip` now it is
`School_name_Certificates.zip`

  - To download you click here:   ![image](https://user-images.githubusercontent.com/60389372/160424554-c39bd163-c8d3-4261-9589-60e200784700.png)

  - Before ![image](https://user-images.githubusercontent.com/60389372/160424127-cba90ff5-a2f3-449d-b288-b9b166b16f20.png)
  - After ![image](https://user-images.githubusercontent.com/60389372/160424228-94a74268-c19e-4868-902d-47d618191a0d.png)


- 247714a6eaa8897fc8bebb68be5dd0d94d2c80f0 Fix issue where participation certificate was generated for absent students.