### PR TITLE
Add field for consenting to receive bursary offers to the Answer sheet

### DIFF
--- a/uctMaths/competition/interface/individual_as_template.html
+++ b/uctMaths/competition/interface/individual_as_template.html
@@ -172,6 +172,8 @@
     <td width=75% style="border-width: 0px; text-align: left;">………………………………………………………………………………..    Tel ………………………………..</td>
   </tr>
   <tr style="border-width: 0px; line-height: 100%;">
+    <td width=25% style="border-width: 0px; text-align: right;"> Please send me </td>
+    <td width=75% style="border-width: 0px; text-align: left;"> information about bursaries &nbsp &nbsp YES / JA &nbsp NO / NEE &nbsp &nbsp Stuur asseblief vir my inligting oor beurse </td>
   </tr>
   <tr style="border-width: 0px; line-height: 100%;">
     <td width=25% style="border-width: 0px; text-align: right;">Signed</td>

--- a/uctMaths/competition/interface/pair_as_template.html
+++ b/uctMaths/competition/interface/pair_as_template.html
@@ -165,6 +165,8 @@
        Language preference: Eng/Afr &nbsp ………………………………………. &nbsp<br>
                      Postal address &nbsp ………………………………………. &nbsp<br>
                               Email	&nbsp ………………………………………. &nbsp<br>
+         Please send me information &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<br>
+                    about bursaries &nbsp YES / NO &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<br>
                              Signed &nbsp ………………………………………. &nbsp<br>
       </td>
     <td style="border-width: 0px; text-align: right; padding-right: 64px;">
@@ -174,6 +176,8 @@
       Taalvoorkeur: Afr/Eng &nbsp	…………………………………………….<br>
       Posadres &nbsp	…………………………………………….<br>
       Epos &nbsp	…………………………………………….<br>
+      Stuur asseblief vir my &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<br>
+      inligting oor beurse &nbsp JA / NEE &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp <br>
       Geteken &nbsp	…………………………………………….<br>
       </td>
   </tr>


### PR DESCRIPTION
Add field for consenting to receive bursary offers to the Answer sheet

- Before this change the answer sheet looked like
![before_individual](https://user-images.githubusercontent.com/60389372/166720603-9e052dad-31c5-4eee-acac-203e931dc4af.png)
![before_pair](https://user-images.githubusercontent.com/60389372/166720614-8bb1a4c6-00e7-4448-8e69-778686cc088e.png)
- After this change the answer sheets look like
![after_individual](https://user-images.githubusercontent.com/60389372/166720657-baabc3f1-c3bf-48b8-b931-3ea5e3db66c6.png)
![after_pair](https://user-images.githubusercontent.com/60389372/166720665-49b6f22c-c58f-4786-a162-96da8aa2eb32.png)

