### PR TITLE
Read scores from new "Ranked.csv" files

### DIFF
--- a/docs/readme/quick_code_doc.tex
+++ b/docs/readme/quick_code_doc.tex
@@ -141,7 +141,7 @@ The logic for \verb|school_report.html| is in \verb|competition/compadmin.py| wh
 \begin{itemize}
 \item \verb|upload_results.html|
 
-This is where the \textbf{uctMaths} app finds the html template for requesting the .RES file from the admin interface. The logic for this is defined \verb|competition/compadmin_views.py|, called from an action defined in \verb|competition/admin.py|
+This is where the \textbf{uctMaths} app finds the html template for requesting the Ranked.csv file from the admin interface. The logic for this is defined \verb|competition/compadmin_views.py|, called from an action defined in \verb|competition/admin.py|
 
 \end{itemize}
 

--- a/docs/userdoc/admin.rst
+++ b/docs/userdoc/admin.rst
@@ -235,11 +235,11 @@ Actions and exports
 
     A .zip archive file is generated containing the files required for the MailMerge program. The names and formatting of the student entries and  file names is based on examples from previous years.
         
-- **Upload students' results (.RES file required)**
+- **Upload students' results (Ranked.csv file required)**
 
     Allows the upload of student results files to the database. Errors are presented to the user on the page after upload has taken place.
 
-    .. note:: The file names are expected to be those as seen in the example files. (eg. INDGR8.RES for INDividuals in grade 8 or PRGR8.RES for Pairs in grade 8.)
+    .. note:: The file names are expected to be those as seen in the example files. (eg. "GR8 IND Ranked.csv" for INDividuals in grade 8 or "GR8 PRS Ranked.csv" for Pairs in grade 8.)
 
 - **Assign awards and export (.xls) document (regardless of selection)**
 
@@ -255,7 +255,7 @@ Actions and exports
 
     Assigns ranks to all students based on their score. 
     
-    .. note:: The ranks are imported when a .RES file is uploaded. However, if you wish to manually disqualify a student, you can delete their score (leave the field blank - which is equivalent to an 'ABSENT') and then use this function to re-rank the remaining students.
+    .. note:: The ranks are imported when a Ranked.csv file is uploaded. However, if you wish to manually disqualify a student, you can delete their score (leave the field blank - which is equivalent to an 'ABSENT') and then use this function to re-rank the remaining students.
 
 - **Assign awards (regardless of selection)**
 

--- a/uctMaths/competition/compadmin.py
+++ b/uctMaths/competition/compadmin.py
@@ -402,7 +402,7 @@ def output_schooltaglists(school_list):
     return response
 
 def upload_results():
-    """Facilitate upload of .RES (the results) files. Redirects to custom Admin page (upload_results.html), the logic contained in compadmin_views.py."""
+    """Facilitate upload of Ranked.csv (the results) files. Redirects to custom Admin page (upload_results.html), the logic contained in compadmin_views.py."""
     #Return response of redirect page
     response = HttpResponseRedirect('../../../../competition/admin/upload_results.html')
     return response
@@ -655,7 +655,7 @@ def makeCertificates(students, assigned_school):
         try:
             certs = []
             for student in students:
-                if student.score == 0:  # student is absent
+                if student.score == 0 or student.score is None:  # student is absent
                     continue
                 award = student.award            
 

--- a/uctMaths/competition/interface/admin/student_changelist.html
+++ b/uctMaths/competition/interface/admin/student_changelist.html
@@ -12,7 +12,7 @@
     <div>
         <form action="upload_results/" method="POST">
             {% csrf_token %}
-                <button type="submit" class="actionButton">Upload students' results (.RES file required)</button>
+                <button type="submit" class="actionButton">Upload students' results (Ranked.csv file required)</button>
         </form>
         <form action="rank_students/" method="POST">
             {% csrf_token %}

--- a/uctMaths/competition/interface/admin/upload_results.html
+++ b/uctMaths/competition/interface/admin/upload_results.html
@@ -2,7 +2,7 @@
 {% block title %}Upload student results{% endblock %}
  
 {% block content %}
-<p> Please select the .RES file that contains the results data of the students for the grade and category (e.g. Grade 8 Individuals), and click Submit. Repeat this process for each grade and category. </p>
+<p> Please select the Ranked.csv file that contains the results data of the students for the grade and category (e.g. Grade 8 Individuals), and click Submit. Repeat this process for each grade and category. </p>
 <form enctype="multipart/form-data" method="post">
    {% csrf_token %}   
    <table>


### PR DESCRIPTION
UCT changed the system they use to generate the results. They can no longer give us ".RES" files but they can give us "Ranked.csv" files.

The ".RES" files had entries for "ABSENT" students for which we set a score of 0. The "Ranked.csv", however, just omit absent students. Thus, with this change, absent students will have a score of `NULL`. As far as I can tell `compadmin.makeCertificates` was the only function
that needed to change to work with `NULL`.

The "Ranked.csv" is a CSV file with the following structure with a few complications

9999999 |   |   |   |   | 2 | 3 | 5 | 3 | 5 | 5 | 1 | 5 | 2 | 5 | 2 | 1 | 4 | 2 | 1 | 4 | 4 | 3 | 3 | 5 | 3 | 4 | 3 | 2 | 3 | 5 | 2 | 2 | 2 | 2 | Rank | Score
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
3510804 | FIRST NAME REDACTED | LAST NAME REDACTED  | B | 8 | 2 | 3 | 5 | 3 | 5 | 5 | 1 | 5 | 2 | 5 | 2 | 1 | 4 | 2 | 1 | 4 | 4 | 3 | 3 | 5 | 3 | 4 | 3 | 2 | 2 | 5 | 2 | 2 | 2 | 2 | 1 | 173
4530807 | FIRST NAME REDACTED | LAST NAME REDACTED| J | 8 | 2 | 3 | 3 | 3 | 5 | 5 | 1 | 5 | 2 | 5 | 2 | 1 | 4 | 2 | 1 | 4 | 4 | 3 | 3 | 5 | 3 | 4 | 3 | 2 | 3 | 5 | 4 | 2 | 2 | 2 | 2 | 168

- Sometimes the first column of ref_num is quoted (e.g. `"3510804"`)
- The number of nines in the heading of the first column can vary.
