### PR TITLE
Bump the django-import-export version

### DIFF
--- a/req.txt
+++ b/req.txt
@@ -3,7 +3,7 @@ Django==1.7
 django-allauth==0.15.0
 django-background-tasks==1.0.15
 django-compat==1.0.15
-django-import-export==0.1.5
+django-import-export==0.7.0
 docutils==0.11
 html5lib==1.0b3
 oauthlib==0.6.0


### PR DESCRIPTION
This bumps the version to the latest that is  supported by this version of Django